### PR TITLE
Inclusive capture boundary for AnyBefore captor

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ Captures the oldest available `Dispatch` elements. Capture range is the stamp as
 
 #### `flow::follower::AnyBefore`
 
-Captures all `Dispatch` elements before the capture range lower bound, minus a `delay` offset. All of the captured elements are removed. 
+Captures all `Dispatch` elements before the capture range lower bound, minus a `delay` offset. All of the captured elements are removed. It can additionally return captured elements exactly at the capture range lower bound by configuring the capture boundary
+to be inclusive.
 
 Capture will report a `flow::State::PRIMED` state even if the buffer is empty, making this captor the ideal choice if you are working with a data stream that is "optional" for the current synchronization attempt.
 

--- a/include/flow/follower/any_before.hpp
+++ b/include/flow/follower/any_before.hpp
@@ -18,8 +18,8 @@ namespace follower
  *
  * This capture buffer will capture data which is behind the driving upper
  * sequence stamp (<code>range.upper_stamp</code>) by some sequencing delay
- * w.r.t a driver-provided target time. It will return all data at and before
- * that sequencing boundary that has not previously been captured.
+ * w.r.t a driver-provided target time. It can be configured to return all data at and before,
+ * or strictly just before, that sequencing boundary that has not previously been captured.
  * \n
  * This capture buffer is always ready, and will always return with a PRIMED state,
  * regardless of whether or not there is data available to capture.
@@ -60,11 +60,13 @@ public:
    * @brief Setup constructor
    *
    * @param delay  the delay with which to capture
+   * @param inclusive_capture_boundary  enable message capture exactly at sequencing boundary
    * @param container  container object with some initial state
    * @param queue_monitor  queue monitor with some initial state
    */
   explicit AnyBefore(
     const offset_type& delay,
+    const bool inclusive_capture_boundary = false,
     const ContainerT& container = ContainerT{},
     const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
@@ -109,6 +111,9 @@ private:
 
   /// Capture delay
   offset_type delay_;
+
+  /// Include message capture at the sequencing boundary
+  const bool inclusive_capture_boundary_;
 };
 
 }  // namespace follower

--- a/test/flow/follower/any_before.cpp
+++ b/test/flow/follower/any_before.cpp
@@ -26,7 +26,7 @@ struct FollowerAnyBefore : ::testing::Test, AnyBefore<Dispatch<int, optional<int
 
   std::vector<Dispatch<int, optional<int>>> data;
 
-  FollowerAnyBefore() : AnyBefore<Dispatch<int, optional<int>>, NoLock>{DELAY} {}
+  FollowerAnyBefore(bool inclusive_boundary) : AnyBefore<Dispatch<int, optional<int>>, NoLock>{DELAY, inclusive_boundary} {}
 
   void SetUp() final
   {
@@ -50,14 +50,26 @@ struct FollowerAnyBefore : ::testing::Test, AnyBefore<Dispatch<int, optional<int
 };
 constexpr int FollowerAnyBefore::DELAY;
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnEmpty)
+// AnyBefore Follower with Non-Inclusive Capture Boundary
+struct FollowerAnyBeforeNonInclusive : FollowerAnyBefore
+{
+  FollowerAnyBeforeNonInclusive() : FollowerAnyBefore(false) {}
+};
+
+// AnyBefore Follower with Inclusive Capture Boundary
+struct FollowerAnyBeforeInclusive : FollowerAnyBefore
+{
+  FollowerAnyBeforeInclusive() : FollowerAnyBefore(true) {}
+};
+
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnEmpty)
 {
   CaptureRange<int> t_range{0, 0};
   ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnDataAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnDataAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -71,7 +83,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedOnDataAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnDataAfterBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnDataAfterBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -85,7 +97,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedOnDataAfterBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnDataAnyBeforeBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -99,7 +111,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeAndAfterBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnDataAnyBeforeAndAfterBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -114,7 +126,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeAndAfterBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeAndAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedOnDataAnyBeforeAndAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -129,7 +141,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedOnDataAnyBeforeAndAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedMultiDataAnyBeforeBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedMultiDataAnyBeforeBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -145,7 +157,7 @@ TEST_F(FollowerAnyBefore, CapturePrimedMultiDataAnyBeforeBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, CapturePrimedMultiDataAnyBeforeAndAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, CapturePrimedMultiDataAnyBeforeAndAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -161,14 +173,14 @@ TEST_F(FollowerAnyBefore, CapturePrimedMultiDataAnyBeforeAndAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnEmpty)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnEmpty)
 {
   CaptureRange<int> t_range{0, 0};
   ASSERT_EQ(State::PRIMED, this->locate(t_range));
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnDataAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnDataAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -178,7 +190,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedOnDataAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnDataAfterBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnDataAfterBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -188,7 +200,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedOnDataAfterBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnDataAnyBeforeBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -198,7 +210,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeAndAfterBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnDataAnyBeforeAndAfterBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -209,7 +221,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeAndAfterBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeAndAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedOnDataAnyBeforeAndAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -220,7 +232,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedOnDataAnyBeforeAndAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedMultiDataAnyBeforeBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedMultiDataAnyBeforeBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -232,7 +244,7 @@ TEST_F(FollowerAnyBefore, LocatePrimedMultiDataAnyBeforeBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, LocatePrimedMultiDataAnyBeforeAndAtBoundary)
+TEST_F(FollowerAnyBeforeNonInclusive, LocatePrimedMultiDataAnyBeforeAndAtBoundary)
 {
   CaptureRange<int> t_range{0, 0};
 
@@ -244,7 +256,218 @@ TEST_F(FollowerAnyBefore, LocatePrimedMultiDataAnyBeforeAndAtBoundary)
 }
 
 
-TEST_F(FollowerAnyBefore, RemovalOnAbort)
+TEST_F(FollowerAnyBeforeNonInclusive, RemovalOnAbort)
+{
+  // Start injecting data
+  const int t0 = 0;
+  int t = t0;
+  int N = 10;
+  while (N--)
+  {
+    this->inject(Dispatch<int, optional<int>>{t, 1});
+    t += 1;
+  }
+
+  this->abort(5);
+
+  ASSERT_EQ(this->size(), static_cast<std::size_t>(DELAY + 5));
+}
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnEmpty)
+{
+  CaptureRange<int> t_range{0, 0};
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnDataAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnDataAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 0U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnDataAnyBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnDataAnyBeforeAndAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 2U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedOnDataAnyBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(this->size(), 2U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 2U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedMultiDataAnyBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 3U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 2U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, CapturePrimedMultiDataAnyBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 0, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+
+  ASSERT_EQ(this->size(), 3U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 3U);
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnEmpty)
+{
+  CaptureRange<int> t_range{0, 0};
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnDataAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnDataAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnDataAnyBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnDataAnyBeforeAndAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedOnDataAnyBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedMultiDataAnyBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, LocatePrimedMultiDataAnyBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 0, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyBeforeInclusive, RemovalOnAbort)
 {
   // Start injecting data
   const int t0 = 0;


### PR DESCRIPTION
*Ticket:* https://fetchrobotics.atlassian.net/browse/RIOT-13719

## Description

The `AnyBefore` captor currently only captures data before the sequencing boundary but does not capture messages exactly at the sequencing boundary.

It would be useful to capture messages that are exactly at the boundary, so that driver messages may be synced with (optional) follower messages that are intentionally created with the same timestamps (in the case of a zero delay) or a fixed timestamp offset.

To avoid potential consequences to code that rely on this captor being non-inclusive, the captor can be made inclusive through a constructor argument (but is non-inclusive by default).

## Tests
1. Unit tests modified/added for both non-inclusive and inclusive AnyBefore captors (successfully ran)
2. Ran the carl navigation suite for in simulation with the flow change (no issues encountered)

## Open questions for reviewers
