### PR TITLE
Add AnyAtOrBefore Captor

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ It should be understood that the data captured by this captor is largely depende
 
 ![AnyBefore](doc/follower/any_before.png)
 
+#### `flow::follower::AnyAtOrBefore`
+
+Captures all `Dispatch` elements at and before the capture range lower bound, minus a `delay` offset. All of the captured elements are removed. 
+
+Capture will report a `flow::State::PRIMED` state even if the buffer is empty, making this captor the ideal choice if you are working with a data stream that is "optional" for the current synchronization attempt and you need to be able to optionally capture elements with the same stamp or at a fixed time offset (specified by the delay) from the driving message stamp.
+
+It should be understood that the data captured by this captor is largely dependent on how data is added to the buffer and when `capture` is called.
+
+
+TODO: Add Image
 
 
 #### `flow::follower::Before`

--- a/include/flow/follower/any_at_or_before.hpp
+++ b/include/flow/follower/any_at_or_before.hpp
@@ -1,9 +1,9 @@
 /**
- * @copyright 2020-present Fetch Robotics Inc.
- * @author Levon Avagyan, Brian Cairl
+ * @copyright 2023 Zebra Technologies
+ * @author Somesh Daga
  */
-#ifndef FLOW_FOLLOWER_ANY_BEFORE_HPP
-#define FLOW_FOLLOWER_ANY_BEFORE_HPP
+#ifndef FLOW_FOLLOWER_ANY_AT_OR_BEFORE_HPP
+#define FLOW_FOLLOWER_ANY_AT_OR_BEFORE_HPP
 
 // Flow
 #include <flow/follower/follower.hpp>
@@ -14,17 +14,17 @@ namespace follower
 {
 
 /**
- * @brief Captures all data elements from a delay before the driving sequencing stamp
+ * @brief Captures all data elements from a delay at and before the driving sequencing stamp
  *
- * This capture buffer will capture data which is behind the driving upper
+ * This capture buffer will capture data which is at and behind the driving upper
  * sequence stamp (<code>range.upper_stamp</code>) by some sequencing delay
- * w.r.t a driver-provided target time. It will return all data before
+ * w.r.t a driver-provided target time. It will return all data at and before
  * that sequencing boundary that has not previously been captured.
  * \n
  * This capture buffer is always ready, and will always return with a PRIMED state,
  * regardless of whether or not there is data available to capture.
  * \n
- * <b>Data removal:</b> Captor will remove all data before the driving time
+ * <b>Data removal:</b> Captor will remove all data at and before the driving time
  * message minus the delay
  *
  * @tparam DispatchT  data dispatch type
@@ -46,15 +46,15 @@ template <
   typename QueueMonitorT = DefaultDispatchQueueMonitor,
   typename AccessStampT = DefaultStampAccess,
   typename AccessValueT = DefaultValueAccess>
-class AnyBefore
-    : public Follower<AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>
+class AnyAtOrBefore
+    : public Follower<AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>
 {
 public:
   /// Data stamp type
-  using stamp_type = typename CaptorTraits<AnyBefore>::stamp_type;
+  using stamp_type = typename CaptorTraits<AnyAtOrBefore>::stamp_type;
 
   /// Data stamp duration type
-  using offset_type = typename CaptorTraits<AnyBefore>::offset_type;
+  using offset_type = typename CaptorTraits<AnyAtOrBefore>::offset_type;
 
   /**
    * @brief Setup constructor
@@ -63,13 +63,14 @@ public:
    * @param container  container object with some initial state
    * @param queue_monitor  queue monitor with some initial state
    */
-  explicit AnyBefore(
+  explicit AnyAtOrBefore(
     const offset_type& delay,
     const ContainerT& container = ContainerT{},
     const QueueMonitorT& queue_monitor = QueueMonitorT{});
 
 private:
-  using PolicyType = Follower<AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>;
+  using PolicyType =
+    Follower<AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>;
   friend PolicyType;
 
   /**
@@ -130,7 +131,8 @@ template <
   typename QueueMonitorT,
   typename AccessStampT,
   typename AccessValueT>
-struct CaptorTraits<follower::AnyBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>
+struct CaptorTraits<
+  follower::AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>>
     : CaptorTraitsFromDispatch<DispatchT>
 {
   /// Underlying dispatch container type
@@ -156,6 +158,6 @@ struct CaptorTraits<follower::AnyBefore<DispatchT, LockPolicyT, ContainerT, Queu
 }  // namespace flow
 
 // Flow (implementation)
-#include <flow/impl/follower/any_before.hpp>
+#include <flow/impl/follower/any_at_or_before.hpp>
 
-#endif  // FLOW_FOLLOWER_ANY_BEFORE_HPP
+#endif  // FLOW_FOLLOWER_ANY_AT_OR_BEFORE_HPP

--- a/include/flow/followers.hpp
+++ b/include/flow/followers.hpp
@@ -6,6 +6,7 @@
 #define FLOW_FOLLOWERS_HPP
 
 // Flow
+#include <flow/follower/any_at_or_before.hpp>
 #include <flow/follower/any_before.hpp>
 #include <flow/follower/before.hpp>
 #include <flow/follower/closest_before.hpp>

--- a/include/flow/impl/follower/any_at_or_before.hpp
+++ b/include/flow/impl/follower/any_at_or_before.hpp
@@ -1,0 +1,98 @@
+/**
+ * @copyright 2023 Zebra Technologies
+ * @author Somesh Daga
+ *
+ * @warning IMPLEMENTATION ONLY: THIS FILE SHOULD NEVER BE INCLUDED DIRECTLY!
+ */
+#ifndef FLOW_IMPL_FOLLOWER_ANY_AT_OR_BEFORE_HPP
+#define FLOW_IMPL_FOLLOWER_ANY_AT_OR_BEFORE_HPP
+
+// C++ Standard Library
+#include <cstdint>
+#include <mutex>
+#include <stdexcept>
+
+
+namespace flow
+{
+namespace follower
+{
+
+template <
+  typename DispatchT,
+  typename LockPolicyT,
+  typename ContainerT,
+  typename QueueMonitorT,
+  typename AccessStampT,
+  typename AccessValueT>
+AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>::AnyAtOrBefore(
+  const offset_type& delay,
+  const ContainerT& container,
+  const QueueMonitorT& queue_monitor) :
+    PolicyType{container, queue_monitor},
+    delay_{delay}
+{}
+
+
+template <
+  typename DispatchT,
+  typename LockPolicyT,
+  typename ContainerT,
+  typename QueueMonitorT,
+  typename AccessStampT,
+  typename AccessValueT>
+std::tuple<State, ExtractionRange>
+AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>::locate_follower_impl(
+  const CaptureRange<stamp_type>& range) const
+{
+  // The boundary before which messages are valid and after which they are not. Non-inclusive.
+  const stamp_type boundary = range.upper_stamp - delay_;
+
+  auto itr = PolicyType::queue_.begin();
+
+  // Collect all the messages that are earlier than the first driving message's
+  // timestamp minus the delay
+  while (itr != PolicyType::queue_.end() and AccessStampT::get(*itr) <= boundary)
+  {
+    ++itr;
+  }
+
+  return std::make_tuple(
+    State::PRIMED, ExtractionRange{0, static_cast<std::size_t>(std::distance(PolicyType::queue_.begin(), itr))});
+}
+
+template <
+  typename DispatchT,
+  typename LockPolicyT,
+  typename ContainerT,
+  typename QueueMonitorT,
+  typename AccessStampT,
+  typename AccessValueT>
+template <typename OutputDispatchIteratorT>
+void AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>::
+  extract_follower_impl(
+    OutputDispatchIteratorT& output,
+    const ExtractionRange& extraction_range,
+    const CaptureRange<stamp_type>& range)
+{
+  output = PolicyType::queue_.move(output, extraction_range);
+  PolicyType::queue_.remove_first_n(extraction_range.last);
+}
+
+template <
+  typename DispatchT,
+  typename LockPolicyT,
+  typename ContainerT,
+  typename QueueMonitorT,
+  typename AccessStampT,
+  typename AccessValueT>
+void AnyAtOrBefore<DispatchT, LockPolicyT, ContainerT, QueueMonitorT, AccessStampT, AccessValueT>::abort_follower_impl(
+  const stamp_type& t_abort)
+{
+  PolicyType::queue_.remove_at_before(t_abort - delay_);
+}
+
+}  // namespace follower
+}  // namespace flow
+
+#endif  // FLOW_IMPL_FOLLOWER_ANY_AT_OR_BEFORE_HPP

--- a/test/flow/follower/any_at_or_before.cpp
+++ b/test/flow/follower/any_at_or_before.cpp
@@ -1,0 +1,264 @@
+/**
+ * @copyright 2023 Zebra Technologies
+ * @author Somesh Daga
+ */
+#ifndef DOXYGEN_SKIP
+
+// C++ Standard Library
+#include <iterator>
+#include <vector>
+
+// GTest
+#include <gtest/gtest.h>
+
+// Flow
+#include <flow/captor/nolock.hpp>
+#include <flow/follower/any_at_or_before.hpp>
+#include <flow/utility/optional.hpp>
+
+using namespace flow;
+using namespace flow::follower;
+
+
+struct FollowerAnyAtOrBefore : ::testing::Test, AnyAtOrBefore<Dispatch<int, optional<int>>, NoLock>
+{
+  static constexpr int DELAY = 1;
+
+  std::vector<Dispatch<int, optional<int>>> data;
+
+  FollowerAnyAtOrBefore() : AnyAtOrBefore<Dispatch<int, optional<int>>, NoLock>{DELAY} {}
+
+  void SetUp() final
+  {
+    this->reset();
+    data.clear();
+  }
+
+  void TearDown() final
+  {
+    this->inspect([](const Dispatch<int, optional<int>>& element) {
+      ASSERT_TRUE(element.value) << "Queue element invalid at stamp(" << element.stamp
+                                 << "). Element is nullopt; likely moved erroneously during capture";
+    });
+
+    for (const auto& element : data)
+    {
+      ASSERT_TRUE(element.value) << "Capture element invalid at stamp(" << element.stamp
+                                 << "). Element is nullopt; likely moved erroneously during capture";
+    }
+  }
+};
+constexpr int FollowerAnyAtOrBefore::DELAY;
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnEmpty)
+{
+  CaptureRange<int> t_range{0, 0};
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnDataAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnDataAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 0U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnDataAnyAtOrBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+
+  ASSERT_EQ(this->size(), 1U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnDataAnyAtOrBeforeAndAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 2U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 1U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedOnDataAnyAtOrBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(this->size(), 2U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 2U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedMultiDataAnyAtOrBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(this->size(), 3U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 1U);
+
+  ASSERT_EQ(data.size(), 2U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, CapturePrimedMultiDataAnyAtOrBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 0, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+
+  ASSERT_EQ(this->size(), 3U);
+  ASSERT_EQ(State::PRIMED, this->capture(std::back_inserter(data), t_range));
+  ASSERT_EQ(this->size(), 0U);
+
+  ASSERT_EQ(data.size(), 3U);
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnEmpty)
+{
+  CaptureRange<int> t_range{0, 0};
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnDataAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnDataAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnDataAnyAtOrBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnDataAnyAtOrBeforeAndAfterBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedOnDataAnyAtOrBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedMultiDataAnyAtOrBeforeBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY + 1, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, LocatePrimedMultiDataAnyAtOrBeforeAndAtBoundary)
+{
+  CaptureRange<int> t_range{0, 0};
+
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 0, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 1, 1});
+  this->inject(Dispatch<int, optional<int>>{-DELAY - 2, 1});
+
+  ASSERT_EQ(State::PRIMED, this->locate(t_range));
+}
+
+
+TEST_F(FollowerAnyAtOrBefore, RemovalOnAbort)
+{
+  // Start injecting data
+  const int t0 = 0;
+  int t = t0;
+  int N = 10;
+  while (N--)
+  {
+    this->inject(Dispatch<int, optional<int>>{t, 1});
+    t += 1;
+  }
+
+  this->abort(5);
+
+  ASSERT_EQ(this->size(), static_cast<std::size_t>(DELAY + 4));
+}
+
+#endif  // DOXYGEN_SKIP


### PR DESCRIPTION
*Ticket:* https://fetchrobotics.atlassian.net/browse/RIOT-13719

## Description

The `AnyBefore` captor currently only captures data before the sequencing boundary but does not capture messages exactly at the sequencing boundary.

It would be useful to capture messages that are exactly at the boundary, so that driver messages may be synced with (optional) follower messages that are intentionally created with the same timestamps (in the case of a zero delay) or a fixed timestamp offset.

To achieve this, a new `AnyAtOrBefore` captor is introduced.

## Tests
1. Unit tests added for `AnyAtOrBefore` captor (successfully ran)
2. Ran the carl navigation suite for in simulation with the new captor (achieved expected behaviour)

## Open questions for reviewers